### PR TITLE
workflows: add CI using github actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,23 @@
+name: gh-actions/site
+
+on: [push, pull_request]
+
+jobs:
+  build:
+    runs-on: ubuntu-18.04
+    strategy:
+      fail-fast: false
+      matrix:
+        ruby: [ '2.5', '2.6', '2.7', '3.0.1' ]
+    name: Ruby ${{ matrix.ruby }}
+    steps:
+      - uses: actions/checkout@v2
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: ${{ matrix.ruby }}
+      - name: install bundler
+        run: gem install bundler
+      - name: bundle install
+        run: bundle install --jobs 4 --retry 3
+      - name: build site
+        run: bundle exec jekyll build


### PR DESCRIPTION
Shamelessly stolen from [Monero](https://github.com/monero-project/monero-site/blob/master/.github/workflows/ci.yml).