### PR TITLE
home: remove link to mailing list

### DIFF
--- a/index.html
+++ b/index.html
@@ -22,13 +22,4 @@ title: Home
             </div>
         </div>
     </div>
-
-    <div class="box">
-        <h1>Want to receive important updates? Join the mailing list!</h1>
-        <div class="list">
-            <div class="listItem">
-                <a class="button button-large" href="https://lists.getmonero.org/postorius/lists/havenodex.lists.getmonero.org/">Subscribe</a>
-            </div>
-        </div>
-    </div>
 </div>


### PR DESCRIPTION
The Monero mailing list is broken and we prefer to drop it. We will probably add a blog page + rss feed instead.