### PR TITLE
sponsors: change classes names to 'benefactors'

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -627,7 +627,7 @@ img.topsponsor {
   cursor: pointer;
 }
 
-.sponsors-container {
+.benefactors-container {
   margin-bottom: 1rem;
   margin-top: 2rem;
   display: flex;
@@ -637,18 +637,18 @@ img.topsponsor {
 }
 
 
-.sponsors-box {
+.benefactors-box {
   width: 8rem;
   height: 8rem;
   margin: 0.5rem 0.9rem;
 }
 
-.sponsors-box:hover {
+.benefactors-box:hover {
   transform: scale(1.1);
   cursor: pointer; 
 }
 
-.sponsors-box img {
+.benefactors-box img {
   max-width: 100%;
   border-radius: 10%;
 }

--- a/sponsors/index.html
+++ b/sponsors/index.html
@@ -62,20 +62,20 @@ permalink: /sponsors/
     <div class="row">
         <h2>Sponsors</h2>
         <p>These entities or individuals generously donated to Haveno, allowing us to fund our <a href="https://https://github.com/orgs/haveno-dex/projects/2">bounty system</a> and pay for infrastructure.</p>
-        <div class="sponsors-container">
-            <div class="sponsors-box">
+        <div class="benefactors-container">
+            <div class="benefactors-box">
                 <a href="https://samouraiwallet.com/"><img src="{{ site.url }}/assets/sponsors/samourai.png" alt="Samourai Wallet logo" Title="Samourai Wallet"></a>
             </div>
-            <div class="sponsors-box">
+            <div class="benefactors-box">
                 <a href="https://cakewallet.com/"><img src="{{ site.url }}/assets/sponsors/cake-logo-blue.jpg" alt="Cake Wallet logo" Title="Cake Wallet"></a>
             </div>
-            <div class="sponsors-box">
+            <div class="benefactors-box">
                 <a href="https://twitter.com/DonYakka"><img src="{{ site.url }}/assets/sponsors/donyakka.jpg" alt="Don Yakka" Title="Don Yakka"></a>
             </div>
-            <div class="sponsors-box">
+            <div class="benefactors-box">
                 <a href="https://twitter.com/mikedogsmd"><img src="{{ site.url }}/assets/sponsors/mikedogsmd.jpg" alt="Mike Dogs, MD" Title="Mike Dogs, MD"></a>
             </div>
-            <div class="sponsors-box">
+            <div class="benefactors-box">
                 <a href="https://beldex.io"><img src="{{ site.url }}/assets/sponsors/beldex.jpg" alt="Beldex" Title="Beldex"></a>
             </div>
         </div>


### PR DESCRIPTION
Some browsers were partially or completely hiding the logos of our sponsors. Changed the class to 'benefactors'.